### PR TITLE
Log encoding command with proper shell quoting

### DIFF
--- a/services/conv/encoders.py
+++ b/services/conv/encoders.py
@@ -3,6 +3,7 @@ from nebula import *
 import subprocess
 import os
 import signal
+import shlex
 
 from .common import *
 
@@ -77,7 +78,7 @@ class NebulaFFMPEG(BaseEncoder):
 
 
     def start(self):
-        logging.debug("Executing {}".format(" ".join(self.ffparams)))
+        logging.debug("Executing {}".format(" ".join(shlex.quote(x) for x in self.ffparams)))
         self.proc = subprocess.Popen(
                 self.ffparams,
                 stderr=subprocess.PIPE,


### PR DESCRIPTION
There are so many special characters in a typical command that it's otherwise very difficult to copy+paste an ffmpeg invocation for debugging purposes.