### PR TITLE
Fix ffprobe on files without a duration (e.g. image files)

### DIFF
--- a/services/meta/ffprobe.py
+++ b/services/meta/ffprobe.py
@@ -154,7 +154,7 @@ class FFProbe(Probe):
                     pass
 
 
-        meta["duration"] = float(format_info["duration"]) or source_vdur or source_adur
+        meta["duration"] = float(format_info.get("duration", 0)) or source_vdur or source_adur
         try:
             meta["num_frames"] = meta["duration"] * meta["video/fps_f"]
         except:


### PR DESCRIPTION
Image files are found by the watch service, but ffprobe (correctly) doesn't have a duration for them. This change prevents the watch service from choking on image files.