### PR TITLE
Reuse HTTP connections in the mesg service to improve performance

### DIFF
--- a/services/mesg/__init__.py
+++ b/services/mesg/__init__.py
@@ -109,9 +109,15 @@ class Service(BaseService):
                 log_traceback()
                 self.log_ttl = None
 
+        self.session = requests.Session()
+
         thread.start_new_thread(self.listen, ())
         thread.start_new_thread(self.process, ())
 
+
+    def shutdown(self, *args, **kwargs):
+        self.session.close()
+        super().shutdown(*args, **kwargs)
 
     def on_main(self):
         if len(self.queue) > 100:
@@ -210,7 +216,7 @@ class Service(BaseService):
         message = message.replace("\n", "") + "\n" # one message per line
         for relay in self.relays:
             try:
-                result = requests.post(relay, message.encode("ascii"), timeout=.5)
+                result = self.session.post(relay, message.encode("ascii"), timeout=.5)
             except:
                 logging.error("Unable to send message to relay", relay)
                 continue


### PR DESCRIPTION
This reduced CPU usage for the mesg service from 40% to 5% on one
machine. The overhead was primarily from re-negotiating the SSL
connection for each message.

I'm not exactly sure why it's still using 5% CPU for the amount of traffic it's handling, but at least it's no longer a big CPU hog.