### PR TITLE
VLC playout controller

### DIFF
--- a/nx/api/playout.py
+++ b/nx/api/playout.py
@@ -25,7 +25,7 @@ def api_playout(**kwargs):
     channel_config = config["playout_channels"][id_channel]
     engine = channel_config.get("engine", "dummy")
 
-    if engine == "casparcg":
+    if engine in ("casparcg", "vlc"):
         if not action in [
                 "cue",
                 "take",

--- a/nx/plugins/playout.py
+++ b/nx/plugins/playout.py
@@ -21,7 +21,6 @@ class PlayoutPluginSlot(object):
 class PlayoutPlugin(object):
     def __init__(self, service):
         self.service = service
-        self.id_layer = self.service.caspar_feed_layer + 1
         self.playout_dir = os.path.join(
                 storages[self.channel_config["playout_storage"]].local_path,
                 self.channel_config["playout_dir"]
@@ -85,6 +84,10 @@ class PlayoutPlugin(object):
             except Exception:
                 log_traceback()
             self.busy = False
+
+    @property
+    def id_layer(self):
+        return self.service.controller.caspar_feed_layer + 1
 
     def layer(self, id_layer=False):
         if not id_layer:

--- a/services/play/caspar_controller.py
+++ b/services/play/caspar_controller.py
@@ -20,6 +20,11 @@ class CasparController(object):
     def __init__(self, parent):
         self.parent = parent
 
+        self.caspar_host         = parent.channel_config.get("caspar_host", "localhost")
+        self.caspar_port         = int(parent.channel_config.get("caspar_port", 5250))
+        self.caspar_channel      = int(parent.channel_config.get("caspar_channel", 1))
+        self.caspar_feed_layer   = int(parent.channel_config.get("caspar_feed_layer", 10))
+
         self.current_item = False
         self.current_fname = False
         self.cued_item = False
@@ -43,7 +48,7 @@ class CasparController(object):
             return
 
         Parser = get_info_parser(self.infc)
-        self.parser = Parser(self.infc, self.parent.caspar_channel)
+        self.parser = Parser(self.infc, self.caspar_channel)
 
         thread.start_new_thread(self.work, ())
 
@@ -53,11 +58,11 @@ class CasparController(object):
 
     @property
     def host(self):
-        return self.parent.caspar_host
+        return self.caspar_host
 
     @property
     def port(self):
-        return self.parent.caspar_port
+        return self.caspar_port
 
     def connect(self):
         if not hasattr(self, "cmdc"):
@@ -97,7 +102,7 @@ class CasparController(object):
             time.sleep(.3)
 
     def main(self):
-        info = self.parser.get_info(self.parent.caspar_feed_layer)
+        info = self.parser.get_info(self.caspar_feed_layer)
         if not info:
             logging.warning("Channel {} update stat failed".format(self.id_channel))
             self.bad_requests += 1
@@ -215,7 +220,7 @@ class CasparController(object):
 
     def cue(self, fname, item, **kwargs):
         auto       = kwargs.get("auto", True)
-        layer      = kwargs.get("layer", self.parent.caspar_feed_layer)
+        layer      = kwargs.get("layer", self.caspar_feed_layer)
         play       = kwargs.get("play", False)
         loop       = kwargs.get("loop", False)
         mark_in    = item.mark_in()
@@ -231,14 +236,14 @@ class CasparController(object):
 
         if play:
             q = "PLAY {}-{} {}{}".format(
-                    self.parent.caspar_channel,
+                    self.caspar_channel,
                     layer,
                     fname,
                     marks
                 )
         else:
             q = "LOADBG {}-{} {} {} {}".format(
-                    self.parent.caspar_channel,
+                    self.caspar_channel,
                     layer,
                     fname,
                     ["","AUTO"][auto],
@@ -264,17 +269,17 @@ class CasparController(object):
 
 
     def clear(self, **kwargs):
-        layer = layer or self.parent.caspar_feed_layer
+        layer = layer or self.caspar_feed_layer
         result = self.query("CLEAR {}-{}".format(self.channel, layer))
         return NebulaResponse(result.response, result.data)
 
 
     def take(self, **kwargs):
-        layer = kwargs.get("layer", self.parent.caspar_feed_layer)
+        layer = kwargs.get("layer", self.caspar_feed_layer)
         if not self.cued_item or self.cueing:
             return NebulaResponse(400, "Unable to take. No item is cued.")
         self.paused = False
-        result = self.query("PLAY {}-{}".format(self.parent.caspar_channel, layer))
+        result = self.query("PLAY {}-{}".format(self.caspar_channel, layer))
         if result.is_success:
             if self.parent.current_live:
                 self.parent.on_live_leave()
@@ -288,13 +293,13 @@ class CasparController(object):
 
 
     def retake(self, **kwargs):
-        layer = kwargs.get("layer", self.parent.caspar_feed_layer)
+        layer = kwargs.get("layer", self.caspar_feed_layer)
         if self.parent.current_live:
             return NebulaResponse(409, "Unable to retake live item")
         seekparam = str(int(self.current_item.mark_in() * self.fps))
         if self.current_item.mark_out():
             seekparam += " LENGTH {}".format(int((self.current_item.mark_out() - self.current_item.mark_in()) * self.parser.seek_fps))
-        q = "PLAY {}-{} {} SEEK {}".format(self.parent.caspar_channel, layer, self.current_fname, seekparam)
+        q = "PLAY {}-{} {} SEEK {}".format(self.caspar_channel, layer, self.current_fname, seekparam)
         self.paused = False
         result = self.query(q)
         if result.is_success:
@@ -309,22 +314,22 @@ class CasparController(object):
 
 
     def freeze(self, **kwargs):
-        layer = kwargs.get("layer", self.parent.caspar_feed_layer)
+        layer = kwargs.get("layer", self.caspar_feed_layer)
         if self.parent.current_live:
             return NebulaResponse(409, "Unable to freeze live item")
         if not self.paused:
-            q = "PAUSE {}-{}".format(self.parent.caspar_channel, layer)
+            q = "PAUSE {}-{}".format(self.caspar_channel, layer)
             message = "Playback paused"
             new_val = True
         else:
             if self.parser.protocol >= 2.07:
-                q = "RESUME {}-{}".format(self.parent.caspar_channel, layer)
+                q = "RESUME {}-{}".format(self.caspar_channel, layer)
             else:
                 length = "LENGTH {}".format(int(
                     (self.current_out or self.fdur) - self.fpos
                     ))
                 q = "PLAY {}-{} {} SEEK {} {}".format(
-                        self.parent.caspar_channel,
+                        self.caspar_channel,
                         layer,
                         self.current_fname,
                         self.fpos,
@@ -344,10 +349,10 @@ class CasparController(object):
 
 
     def abort(self, **kwargs):
-        layer = kwargs.get("layer", self.parent.caspar_feed_layer)
+        layer = kwargs.get("layer", self.caspar_feed_layer)
         if not self.cued_item:
             return NebulaResponse(400, "Unable to abort. No item is cued.")
-        q = "LOAD {}-{} {}".format(self.parent.caspar_channel, layer, self.cued_fname)
+        q = "LOAD {}-{} {}".format(self.caspar_channel, layer, self.cued_fname)
         if self.cued_item.mark_in():
             q += " SEEK {}".format(int(self.cued_item.mark_in() * self.parser.seek_fps))
         if self.cued_item.mark_out():

--- a/services/play/vlc_controller.py
+++ b/services/play/vlc_controller.py
@@ -42,10 +42,15 @@ class VlcMedia(object):
 
         # TODO: set self.fname from self.media.get_mrl()?
 
+    def __del__(self):
+        self.media.release()
+
     def parse_callback(self, event):
         self.parsed = True
         # TODO: Provide a way to block on this and check if media.get_parsed_status() == MediaParsedStatus.done
-        print("parsed media", event)
+        logging.debug("parsed media", self.fname, event.u.new_status)
+        # Clean up event handler to prevent memory leak
+        self.media.event_manager().event_detach(vlc.EventType.MediaParsedChanged)
 
     @property
     def mark_in_ms(self):

--- a/services/play/vlc_controller.py
+++ b/services/play/vlc_controller.py
@@ -1,0 +1,257 @@
+__all__ = ["VlcController"]
+
+import os
+import time
+import vlc
+
+try:
+    import _thread as thread
+except ImportError:
+    import thread
+
+
+from nebula import *
+
+
+class VlcMedia(object):
+    def __init__(self, instance, fname, item, **kwargs):
+        self.auto       = kwargs.get("auto", True)
+        layer      = kwargs.get("layer", self.caspar_feed_layer)
+        loop       = kwargs.get("loop", False)
+        self.mark_in    = item.mark_in()
+        self.mark_out   = item.mark_out()
+
+        self.item = item
+        self.fname = fname
+
+        self.parsed = False
+        self.media = self.instance.media_new(fname)
+        if loop:
+            self.media.add_option(":repeat")
+        # NB: Times are input as float seconds, but all other VLC functions use milliseconds.
+        if self.mark_in:
+            self.media.add_option(":start-time=%f" % self.mark_in)
+        if self.mark_out:
+            self.media.add_option(":stop-time=%f" % self.mark_out)
+
+        self.media.event_manager().event_attach(
+            vlc.EventType.MediaParsedChanged, self.parse_callback)
+
+        ret = self.media.parse_with_options(0, -1)
+        if ret != 0:
+            raise ValueError("failed to parse media")
+
+        # TODO: set self.fname from self.media.get_mrl()?
+
+    def parse_callback(self, event):
+        self.parsed = True
+        # TODO: Provide a way to block on this and check if media.get_parsed_status() == MediaParsedStatus.done
+        print("parsed media", event)
+
+    @property
+    def mark_in_ms(self):
+        return self.mark_in * 1000
+
+    @property
+    def mark_out_ms(self):
+        return self.mark_out * 1000
+
+class VlcController(object):
+    def __init__(self, parent):
+        self.parent = parent
+
+        # VLC always uses milliseconds for timestamps
+        self.parent.fps = 1000
+
+        self.caspar_feed_layer   = int(parent.channel_config.get("caspar_feed_layer", 10))
+
+        self.current = None
+        self.cued = None
+
+        self.args = parent.channel_config.get("vlc_args", "--fullscreen")
+
+        self.instance = vlc.Instance(self.args)
+        self.media_player = self.instance.media_player_new()
+        self.media_player.set_fullscreen(True)
+        self.media_player.event_manager().event_attach(
+            vlc.EventType.MediaPlayerEndReached, self.next_item_callback)
+        # MediaPlayerMediaChanged
+
+        thread.start_new_thread(self.work, ())
+
+    @property
+    def current_item(self):
+        if self.current:
+            return self.current.item
+
+    @property
+    def cued_item(self):
+        if self.cued:
+            return self.cued.item
+
+    @property
+    def current_fname(self):
+        if self.current:
+            return self.current.fname
+        return False
+
+    @property
+    def cued_fname(self):
+        if self.cued:
+            return self.cued.fname
+        return False
+
+    @property
+    def cueing(self):
+        return self.cued and not self.cued.parsed
+
+    @cueing.setter
+    def cueing(self, value):
+        # Ignore play service's attempt to set this
+        pass
+
+    @property
+    def request_time(self):
+        """Time of last status update (always now for VLC)."""
+        return time.time()
+
+    @property
+    def id_channel(self):
+        return self.parent.id_channel
+
+    @property
+    def fps(self):
+        return self.parent.fps
+
+    @property
+    def fpos(self):
+        return self.media_player.get_time()
+
+    @property
+    def fdur(self):
+        return self.media_player.get_length()
+
+    @property
+    def paused(self):
+        return self.media_player.get_state() == vlc.State.Paused
+
+    @property
+    def position(self):
+        if self.current:
+            return int(self.fpos - self.current.mark_in_ms)
+        return 0
+
+    @property
+    def duration(self):
+        if self.parent.current_live or not self.current:
+            return 0
+        dur = self.fdur
+        if self.current.mark_out_ms > 0:
+            dur = self.current.mark_out_ms
+        if self.current.mark_in_ms > 0:
+            dur -= self.current.mark_in_ms
+        return dur
+
+    def work(self):
+        while True:
+            try:
+                self.main()
+            except Exception:
+                log_traceback()
+            time.sleep(.3)
+
+    def next_item_callback(self, event):
+        print(event.u)
+        if self.cued and self.cued.auto:
+            # If we try to manipulate the player from within the callback, we'll deadlock.
+            thread.start_new_thread(self.take, ())
+
+    def main(self):
+        if self.current_item and not self.cued_item:
+            self.parent.cue_next()
+
+        try:
+            self.parent.on_progress()
+        except Exception:
+            log_traceback("Playout on_main failed")
+
+
+    def cue(self, fname, item, **kwargs):
+        self.cued = VlcMedia(self.instance, fname, item, **kwargs)
+        layer      = kwargs.get("layer", self.caspar_feed_layer)
+        play       = kwargs.get("play", False)
+
+        if play:
+            return self.take()
+
+        message = "Cued item {} ({})".format(self.cued_item, fname)
+
+        return NebulaResponse(200, message)
+
+
+    def clear(self, **kwargs):
+        layer = layer or self.caspar_feed_layer
+        self.media_player.stop()
+        self.current = None
+        self.cued = None
+        return NebulaResponse(200, "all items removed")
+
+
+    def take(self, **kwargs):
+        layer = kwargs.get("layer", self.caspar_feed_layer)
+        if not self.cued_item:
+            return NebulaResponse(400, "Unable to take. No item is cued.")
+
+        self.media_player.set_media(self.cued.media)
+        self.media_player.play()
+
+        self.current = self.cued
+        self.cued = None
+
+        self.parent.on_change()
+
+        # TODO: Check if media actually starts playing
+        if True:
+            if self.parent.current_live:
+                self.parent.on_live_leave()
+            code = 200
+            message = "Take OK"
+        else:
+            code = 500
+            message = "Take command failed"
+        return NebulaResponse(code, message)
+
+
+    def retake(self, **kwargs):
+        layer = kwargs.get("layer", self.caspar_feed_layer)
+        if self.parent.current_live:
+            return NebulaResponse(409, "Unable to retake live item")
+        if not self.current:
+            return NebulaResponse(400, "Unable to retake. No item is playing.")
+        self.media_player.set_time(self.current.mark_in_ms)
+        message = "Retake OK"
+        self.parent.cue_next()
+        return NebulaResponse(200, message)
+
+
+    def freeze(self, **kwargs):
+        layer = kwargs.get("layer", self.caspar_feed_layer)
+        if self.parent.current_live:
+            return NebulaResponse(409, "Unable to freeze live item")
+        if not self.paused:
+            self.media_player.set_pause(True)
+            message = "Playback paused"
+        else:
+            self.media_player.set_pause(False)
+            message = "Playback resumed"
+
+        return NebulaResponse(200, message)
+
+
+    def abort(self, **kwargs):
+        layer = kwargs.get("layer", self.caspar_feed_layer)
+        if not self.cued:
+            return NebulaResponse(400, "Unable to abort. No item is cued.")
+        self.media_player.next()
+        self.media_player.set_pause(True)
+        return NebulaResponse(200, "Current item aborted")

--- a/services/play/vlc_controller.py
+++ b/services/play/vlc_controller.py
@@ -14,18 +14,17 @@ from nebula import *
 
 
 class VlcMedia(object):
-    def __init__(self, instance, fname, item, **kwargs):
+    def __init__(self, instance, full_path, item, **kwargs):
         self.auto       = kwargs.get("auto", True)
-        layer      = kwargs.get("layer", self.caspar_feed_layer)
         loop       = kwargs.get("loop", False)
         self.mark_in    = item.mark_in()
         self.mark_out   = item.mark_out()
 
         self.item = item
-        self.fname = fname
+        self.fname = full_path
 
         self.parsed = False
-        self.media = self.instance.media_new(fname)
+        self.media = instance.media_new(self.fname)
         if loop:
             self.media.add_option(":repeat")
         # NB: Times are input as float seconds, but all other VLC functions use milliseconds.
@@ -176,15 +175,15 @@ class VlcController(object):
             log_traceback("Playout on_main failed")
 
 
-    def cue(self, fname, item, **kwargs):
-        self.cued = VlcMedia(self.instance, fname, item, **kwargs)
+    def cue(self, item, full_path, **kwargs):
+        self.cued = VlcMedia(self.instance, full_path, item, **kwargs)
         layer      = kwargs.get("layer", self.caspar_feed_layer)
         play       = kwargs.get("play", False)
 
         if play:
             return self.take()
 
-        message = "Cued item {} ({})".format(self.cued_item, fname)
+        message = "Cued item {} ({})".format(self.cued_item, full_path)
 
         return NebulaResponse(200, message)
 


### PR DESCRIPTION
CasparCG has lots of features but it's also a resource hog; this PR adds support for using VLC as a playout system instead of CasparCG.

I'd really appreciate your input on whether I've captured the state machine properly here; the caspar_controller state machine has a ton of twisty edge cases and I'm not sure I quite got my head around it correctly. Basically, it just implements cue() to set the cued item and take() to make the cued item into the current item and start playing. I think that matches what the Caspar controller does.

This PR also adds support for playing remote files; I don't think CasparCG can do that, but VLC will happily play a file in an arbitrary codec from a remote mountpoint.